### PR TITLE
Add lighting `--inspect` mode/flag

### DIFF
--- a/KCTools/Program.cs
+++ b/KCTools/Program.cs
@@ -64,6 +64,9 @@ public class RootCommand
         [CliOption(Description = "Use a simpler Light to Cell visibility calculation. Only use for debugging.")]
         public bool SimpleVis { get; set; } = false;
 
+        [CliOption(Description = "Report light configuration problems without performing any lighting.")]
+        public bool Inspect { get; set; } = false;
+
         [CliOption(Description = "Disable terminal output.")]
         public bool Quiet { get; set; } = false;
 
@@ -83,8 +86,15 @@ public class RootCommand
                 }
 
                 var lightMapper = new LightMapper(pathManager, CampaignName ?? "", MissionName);
-                lightMapper.Light(SimpleVis);
-                lightMapper.Save(OutputName ?? Path.GetFileNameWithoutExtension(MissionName));
+                if (Inspect)
+                {
+                    lightMapper.Inspect();
+                }
+                else
+                {
+                    lightMapper.Light(SimpleVis);
+                    lightMapper.Save(OutputName ?? Path.GetFileNameWithoutExtension(MissionName));
+                }
             });
             Timing.LogAll();
         }

--- a/KeepersCompound.Lighting/LightMapper.cs
+++ b/KeepersCompound.Lighting/LightMapper.cs
@@ -123,6 +123,8 @@ public class LightMapper
         }
 
         Timing.TimeStage("Gather Lights", () => BuildLightList(settings));
+        Timing.TimeStage("Validate Lights", () => ValidateLightConfigurations(settings));
+        Timing.TimeStage("Build Lighting Table", BuildLightingTable);
         Timing.TimeStage("Set Light Visibility", () => SetCellLightIndices(settings));
         Timing.TimeStage("Trace Scene", () => TraceScene(settings));
         Timing.TimeStage("Update AnimLight Cell Mapping", SetAnimLightCellMaps);
@@ -216,14 +218,10 @@ public class LightMapper
     {
         _lights.Clear();
 
-        // Get the chunks we need
-        if (!_mission.TryGetChunk<WorldRep>("WREXT", out var worldRep) ||
-            !_mission.TryGetChunk<BrList>("BRLIST", out var brList))
+        if (!_mission.TryGetChunk<BrList>("BRLIST", out var brList))
         {
             return;
         }
-
-        worldRep.LightingTable.Reset();
 
         // TODO: Calculate the actual effective radius of infinite lights
         // potentially do the same for all lights and lower their radius if necessary?
@@ -239,9 +237,15 @@ public class LightMapper
                     break;
             }
         }
+    }
 
-        ValidateLightConfigurations(settings);
-
+    private void BuildLightingTable()
+    {
+        if (!_mission.TryGetChunk<WorldRep>("WREXT", out var worldRep))
+        {
+            return;
+        }
+        
         worldRep.LightingTable.Reset();
         foreach (var light in _lights)
         {

--- a/KeepersCompound.Lighting/LightMapper.cs
+++ b/KeepersCompound.Lighting/LightMapper.cs
@@ -141,6 +141,25 @@ public class LightMapper
         }
     }
 
+    public void Inspect()
+    {
+        if (!_mission.TryGetChunk<LmParams>("LM_PARAM", out var lmParams))
+        {
+            return;
+        }
+
+        if (lmParams.AnimLightCutoff > 0)
+        {
+            Log.Warning(
+                "Non-zero anim_light_cutoff ({Cutoff}). AnimLight lightmap shadow radius may not match lightgem shadow radius.",
+                lmParams.AnimLightCutoff);
+        }
+
+        var settings = new Settings();
+        Timing.TimeStage("Gather Lights", () => BuildLightList(settings));
+        Timing.TimeStage("Validate Lights", () => ValidateLightConfigurations(settings));
+    }
+
     public void Save(string missionName)
     {
         var ext = Path.GetExtension(_misPath);


### PR DESCRIPTION
If you're using NewDark 1.28 and using `kctools light` within DromEd you'll likely use the `--quiet` flag because the light configuration reports aren't really visible. So configuration checks will be run outside of dromed, and the actual lighting behaviour might not be required.

This PR adds an inspection only mode that performs all of the validation steps and reporting without actually doing any lighting.