### PR TITLE
Fix incorrect model transforms in some cases

### DIFF
--- a/KCTools/Program.cs
+++ b/KCTools/Program.cs
@@ -275,7 +275,7 @@ public class RootCommand
                         }
                     }
 
-                    var transform = subObject.JointIdx == -1
+                    var transform = subObject.JointType == ModelFile.JointType.None || subObject.JointIdx == -1
                         ? AffineTransform.Identity
                         : AffineTransform.CreateDecomposed(subObject.Transform);
                     var node = new NodeBuilder(subObject.Name);

--- a/KeepersCompound.LGS/ModelFile.cs
+++ b/KeepersCompound.LGS/ModelFile.cs
@@ -153,7 +153,9 @@ public class ModelFile
         {
             var subObj = Objects[i];
             var objTrans = Matrix4x4.Identity;
-            if (subObj.JointIdx != -1)
+
+            // TODO: Slide joints!
+            if (subObj.JointType == JointType.Rotate && subObj.JointIdx != -1)
             {
                 var ang = subObj.JointIdx >= joints.Length ? 0 : float.DegreesToRadians(joints[subObj.JointIdx]);
                 // TODO: Is this correct? Should I use a manual rotation matrix?

--- a/KeepersCompound.LGS/ModelFile.cs
+++ b/KeepersCompound.LGS/ModelFile.cs
@@ -154,13 +154,17 @@ public class ModelFile
             var subObj = Objects[i];
             var objTrans = Matrix4x4.Identity;
 
-            // TODO: Slide joints!
             if (subObj.JointType == JointType.Rotate && subObj.JointIdx != -1)
             {
                 var ang = subObj.JointIdx >= joints.Length ? 0 : float.DegreesToRadians(joints[subObj.JointIdx]);
-                // TODO: Is this correct? Should I use a manual rotation matrix?
                 var jointRot = Matrix4x4.CreateFromYawPitchRoll(0, ang, 0);
                 objTrans = jointRot * subObj.Transform;
+            }
+            else if (subObj.JointType == JointType.Slide && subObj.JointIdx != -1)
+            {
+                var dist = subObj.JointIdx >= joints.Length ? 0 : joints[subObj.JointIdx];
+                var translation = Matrix4x4.CreateTranslation(dist, 0, 0);
+                objTrans = translation * subObj.Transform;
             }
 
             subObjTransforms[i] = objTrans;


### PR DESCRIPTION
Closes #48 
Closes #49 

Turns out some sub-objects with Static joint type have the joint index set unnecessarily and this was resulting in zeroed out transforms being applied incorrectly. Additionally Slide joints were being applied as rotations whoopsie.