### PR TITLE
Add initial work on separate Formats project

### DIFF
--- a/KCTools.sln
+++ b/KCTools.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KeepersCompound.Lighting", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KCLight.Gui", "KCLight.Gui\KCLight.Gui.csproj", "{5219BE09-630C-410A-AD37-0E3DD334DA23}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KeepersCompound.Formats", "KeepersCompound.Formats\KeepersCompound.Formats.csproj", "{6527C66E-A2B5-4172-8663-B27C097D3F14}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,5 +38,9 @@ Global
 		{5219BE09-630C-410A-AD37-0E3DD334DA23}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5219BE09-630C-410A-AD37-0E3DD334DA23}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5219BE09-630C-410A-AD37-0E3DD334DA23}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6527C66E-A2B5-4172-8663-B27C097D3F14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6527C66E-A2B5-4172-8663-B27C097D3F14}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6527C66E-A2B5-4172-8663-B27C097D3F14}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6527C66E-A2B5-4172-8663-B27C097D3F14}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/KeepersCompound.Formats/BinaryExtensions.cs
+++ b/KeepersCompound.Formats/BinaryExtensions.cs
@@ -1,0 +1,60 @@
+using System.Numerics;
+using System.Text;
+
+namespace KeepersCompound.Formats;
+
+public static class BinaryExtensions
+{
+    public static Vector3 ReadRotation(this BinaryReader reader)
+    {
+        var raw = new Vector3(reader.ReadUInt16(), reader.ReadUInt16(), reader.ReadUInt16());
+        return raw * 360 / (ushort.MaxValue + 1);
+    }
+
+    public static void WriteRotation(this BinaryWriter writer, Vector3 rotation)
+    {
+        var raw = rotation * (ushort.MaxValue + 1) / 360;
+        writer.Write((ushort)raw.X);
+        writer.Write((ushort)raw.Y);
+        writer.Write((ushort)raw.Z);
+    }
+
+    public static Vector3 ReadVec3(this BinaryReader reader)
+    {
+        return new Vector3(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
+    }
+
+    public static void WriteVec3(this BinaryWriter writer, Vector3 vec)
+    {
+        writer.Write(vec.X);
+        writer.Write(vec.Y);
+        writer.Write(vec.Z);
+    }
+
+    public static Vector2 ReadVec2(this BinaryReader reader)
+    {
+        return new Vector2(reader.ReadSingle(), reader.ReadSingle());
+    }
+
+    public static void WriteVec2(this BinaryWriter writer, Vector2 vec)
+    {
+        writer.Write(vec.X);
+        writer.Write(vec.Y);
+    }
+
+    public static string ReadNullString(this BinaryReader reader, int length)
+    {
+        var tmpName = Encoding.UTF8.GetString(reader.ReadBytes(length));
+        var idx = tmpName.IndexOf('\0');
+        if (idx >= 0) tmpName = tmpName[..idx];
+        return tmpName;
+    }
+
+    public static void WriteNullString(this BinaryWriter writer, string nullString, int length)
+    {
+        var writeBytes = new byte[length];
+        var stringBytes = Encoding.UTF8.GetBytes(nullString);
+        stringBytes[..Math.Min(length, stringBytes.Length)].CopyTo(writeBytes, 0);
+        writer.Write(writeBytes);
+    }
+}

--- a/KeepersCompound.Formats/Db/Chunks/GenericChunk.cs
+++ b/KeepersCompound.Formats/Db/Chunks/GenericChunk.cs
@@ -1,0 +1,18 @@
+namespace KeepersCompound.Formats.Db.Chunks;
+
+public class GenericChunk : IChunk
+{
+    public string Name { get; set; }
+    public Version Version { get; set; }
+    public byte[] Data { get; set; } = [];
+
+    public void ReadData(BinaryReader reader, TocEntry entry)
+    {
+        Data = reader.ReadBytes((int)entry.Size);
+    }
+
+    public void WriteData(BinaryWriter writer)
+    {
+        writer.Write(Data);
+    }
+}

--- a/KeepersCompound.Formats/Db/Chunks/IChunk.cs
+++ b/KeepersCompound.Formats/Db/Chunks/IChunk.cs
@@ -1,0 +1,35 @@
+using System.Text;
+
+namespace KeepersCompound.Formats.Db.Chunks;
+
+public interface IChunk
+{
+    public string Name { get; set; }
+    public Version Version { get; set; }
+
+    public void Read(BinaryReader reader, TocEntry entry)
+    {
+        reader.BaseStream.Seek(entry.Offset, SeekOrigin.Begin);
+
+        Name = reader.ReadNullString(12);
+        Version = new Version(reader);
+        reader.ReadBytes(4);
+
+        ReadData(reader, entry);
+    }
+
+    public void Write(BinaryWriter writer)
+    {
+        var writeBytes = new byte[12];
+        var nameBytes = Encoding.UTF8.GetBytes(Name);
+        nameBytes[..Math.Min(12, nameBytes.Length)].CopyTo(writeBytes, 0);
+        writer.Write(writeBytes);
+        Version.Write(writer);
+        writer.Write(new byte[4]);
+
+        WriteData(writer);
+    }
+
+    public void ReadData(BinaryReader reader, TocEntry entry);
+    public void WriteData(BinaryWriter writer);
+}

--- a/KeepersCompound.Formats/Db/DbFile.cs
+++ b/KeepersCompound.Formats/Db/DbFile.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using KeepersCompound.Formats.Db.Chunks;
+
+namespace KeepersCompound.Formats.Db;
+
+public class DbFile
+{
+    public Version Version { get; set; }
+    public string DeadBeef { get; set; }
+    public List<TocEntry> TocEntries { get; set; }
+    public List<IChunk> Chunks { get; set; }
+
+    public DbFile(Stream stream)
+    {
+        using var reader = new BinaryReader(stream, Encoding.UTF8, true);
+
+        // Header
+        var tocOffset = reader.ReadUInt32();
+        Version = new Version(reader);
+        reader.ReadBytes(256);
+        DeadBeef = BitConverter.ToString(reader.ReadBytes(4));
+
+        // Table of contents
+        reader.BaseStream.Seek(tocOffset, SeekOrigin.Begin);
+        var entryCount = reader.ReadUInt32();
+        TocEntries = new List<TocEntry>((int)entryCount);
+        for (var i = 0; i < entryCount; i++)
+        {
+            TocEntries.Add(new TocEntry(
+                Name: reader.ReadNullString(12),
+                Offset: reader.ReadUInt32(),
+                Size: reader.ReadUInt32()
+            ));
+        }
+
+        // Chunks
+        Chunks = new List<IChunk>((int)entryCount);
+        foreach (var entry in TocEntries)
+        {
+            var chunk = NewChunk(entry.Name);
+            chunk.Read(reader, entry);
+            Chunks.Add(chunk);
+        }
+    }
+
+    public void Write(Stream stream)
+    {
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, true);
+
+        // Offset is left blank in the header for now, will be filled in later
+        writer.Write(new byte[4]);
+        Version.Write(writer);
+        writer.Write(new byte[256]);
+        writer.Write(Array.ConvertAll(DeadBeef.Split('-'),
+            s => byte.Parse(s, System.Globalization.NumberStyles.HexNumber)));
+
+        // Chunks
+        TocEntries.Clear();
+        foreach (var chunk in Chunks)
+        {
+            var name = chunk.Name;
+            var offset = writer.BaseStream.Position;
+            chunk.Write(writer);
+
+            // Entry size doesn't include the fixed-length of the chunk header
+            var size = writer.BaseStream.Position - offset - 24;
+
+            TocEntries.Add(new TocEntry(name, (uint)offset, (uint)size));
+        }
+
+        // Table of contents
+        var tocOffset = (uint)writer.BaseStream.Position;
+        writer.Write((uint)TocEntries.Count);
+        foreach (var entry in TocEntries)
+        {
+            writer.WriteNullString(entry.Name, 12);
+            writer.Write(entry.Offset);
+            writer.Write(entry.Size);
+        }
+
+        // Backfill the toc offset now that we know it
+        stream.Seek(0, SeekOrigin.Begin);
+        writer.Write(tocOffset);
+    }
+
+    public bool TryGetChunk<T>([MaybeNullWhen(false)] out T chunk) where T : IChunk
+    {
+        chunk = (T?)Chunks.FirstOrDefault(e => e is T);
+        return chunk != null;
+    }
+
+    private static IChunk NewChunk(string entryName)
+    {
+        return entryName switch
+        {
+            _ => new GenericChunk(),
+        };
+    }
+}

--- a/KeepersCompound.Formats/Db/TocEntry.cs
+++ b/KeepersCompound.Formats/Db/TocEntry.cs
@@ -1,0 +1,9 @@
+namespace KeepersCompound.Formats.Db;
+
+public record TocEntry(string Name, uint Offset, uint Size)
+{
+    public override string ToString()
+    {
+        return $"Name: {Name}, Offset: {Offset}, Size: {Size}";
+    }
+}

--- a/KeepersCompound.Formats/Db/Version.cs
+++ b/KeepersCompound.Formats/Db/Version.cs
@@ -1,0 +1,24 @@
+namespace KeepersCompound.Formats.Db;
+
+public class Version
+{
+    public uint Major { get; set; }
+    public uint Minor { get; set; }
+
+    public Version(BinaryReader reader)
+    {
+        Major = reader.ReadUInt32();
+        Minor = reader.ReadUInt32();
+    }
+
+    public void Write(BinaryWriter writer)
+    {
+        writer.Write(Major);
+        writer.Write(Minor);
+    }
+
+    public override string ToString()
+    {
+        return $"{Major}.{Minor}";
+    }
+}

--- a/KeepersCompound.Formats/IBinaryParser.cs
+++ b/KeepersCompound.Formats/IBinaryParser.cs
@@ -1,0 +1,7 @@
+namespace KeepersCompound.Formats;
+
+public interface IBinaryParser<out T>
+{
+    public T? Read(BinaryReader reader);
+    public void Write(BinaryWriter writer);
+}

--- a/KeepersCompound.Formats/KeepersCompound.Formats.csproj
+++ b/KeepersCompound.Formats/KeepersCompound.Formats.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Library</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+</Project>

--- a/KeepersCompound.Formats/KeepersCompound.Formats.csproj
+++ b/KeepersCompound.Formats/KeepersCompound.Formats.csproj
@@ -7,4 +7,8 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Serilog" Version="4.3.0" />
+    </ItemGroup>
+
 </Project>

--- a/KeepersCompound.Formats/Model/ModelFile.cs
+++ b/KeepersCompound.Formats/Model/ModelFile.cs
@@ -1,0 +1,103 @@
+using System.Numerics;
+
+namespace KeepersCompound.Formats.Model;
+
+/// <summary>
+/// Structure representing a Dark Engine .BIN model file. Read and write using a <see cref="ModelFileParser"/>.
+/// </summary>
+public class ModelFile
+{
+    /// <summary>
+    /// Version of BSP used to generate model. Supported versions are 3 and 4.
+    /// </summary>
+    public required int Version { get; set; }
+
+    /// <summary>
+    /// Maximum 8 characters. Additional characters will be truncated on write.
+    /// </summary>
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// Model bounding sphere radius centered on (0, 0, 0).
+    /// </summary>
+    public required float Radius { get; set; }
+
+    /// <summary>
+    /// Maximum bounding sphere radius of the models polygons.
+    /// </summary>
+    public required float MaxPolygonRadius { get; set; }
+
+    /// <summary>
+    /// Minimum point of the models AABB
+    /// </summary>
+    public required Vector3 MinBounds { get; set; }
+
+    /// <summary>
+    /// Maximum point of the models AABB
+    /// </summary>
+    public required Vector3 MaxBounds { get; set; }
+
+    /// <summary>
+    /// Model center offset
+    /// </summary>
+    public required Vector3 Center { get; set; }
+
+    /// <summary>
+    /// Uses transparency on one or more materials. Only supported on version 4.
+    /// </summary>
+    public required bool Transparency { get; set; }
+
+    /// <summary>
+    /// Uses self-illumination on one or more materials. Only supported on version 4.
+    /// </summary>
+    public required bool SelfIllumination { get; set; }
+
+    /// <summary>
+    /// Number of joints/parameters. DromEd can only interact with the first 6.
+    /// </summary>
+    public required ushort JointCount { get; set; }
+
+    /// <summary>
+    /// Number of VCalls in the BSP tree
+    /// </summary>
+    public required byte VCallCount { get; set; }
+
+    /// <summary>
+    /// Global vertex position list
+    /// </summary>
+    public required List<Vector3> VertexPositions { get; set; }
+
+    /// <summary>
+    /// Global vertex UV list
+    /// </summary>
+    public required List<Vector2> VertexUvs { get; set; }
+
+    /// <summary>
+    /// Global vertex normal list
+    /// </summary>
+    public required List<ModelVertexNormal> VertexNormals { get; set; }
+
+    /// <summary>
+    /// Global face normal list
+    /// </summary>
+    public required List<Vector3> FaceNormals { get; set; }
+
+    /// <summary>
+    /// Global polygon list
+    /// </summary>
+    public required List<ModelPolygon> Polygons { get; set; }
+
+    /// <summary>
+    /// Global vhot list. Each vhot must have a unique <see cref="ModelVHotType"/>.
+    /// </summary>
+    public required List<ModelVHot> VHots { get; set; }
+
+    public required List<ModelMaterial> Materials { get; set; }
+
+    public required List<ModelObject> Objects { get; set; }
+
+    /// <summary>
+    /// Unknown structure at this point.
+    /// </summary>
+    public required List<byte> BspNodeData { get; set; }
+}

--- a/KeepersCompound.Formats/Model/ModelFileParser.cs
+++ b/KeepersCompound.Formats/Model/ModelFileParser.cs
@@ -1,0 +1,282 @@
+using System.Drawing;
+using System.Numerics;
+
+namespace KeepersCompound.Formats.Model;
+
+public class ModelFileParser : IBinaryParser<ModelFile>
+{
+    public ModelFile? Read(BinaryReader reader)
+    {
+        reader.BaseStream.Position = 0;
+        if (reader.BaseStream.Length < 8)
+        {
+            return null;
+        }
+
+        var signature = reader.ReadNullString(4);
+        var version = reader.ReadInt32();
+        if (signature != "LGMD" || version < 3)
+        {
+            return null;
+        }
+
+        var name = reader.ReadNullString(8);
+        var radius = reader.ReadSingle();
+        var maxPolygonRadius = reader.ReadSingle();
+        var maxBounds = reader.ReadVec3();
+        var minBounds = reader.ReadVec3();
+        var center = reader.ReadVec3();
+        var polygonCount = reader.ReadUInt16();
+        var vertexPositionCount = reader.ReadUInt16();
+        var jointCount = reader.ReadUInt16();
+        var materialCount = reader.ReadByte();
+        var vCallCount = reader.ReadByte();
+        var vHotCount = reader.ReadByte();
+        var objectCount = reader.ReadByte();
+        var objectOffset = reader.ReadUInt32();
+        var materialOffset = reader.ReadUInt32();
+        var vertexUvOffset = reader.ReadUInt32();
+        var vHotOffset = reader.ReadUInt32();
+        var vertexPositionOffset = reader.ReadUInt32();
+        var vertexNormalOffset = reader.ReadUInt32();
+        var faceNormalOffset = reader.ReadUInt32();
+        var polygonOffset = reader.ReadUInt32();
+        var nodeOffset = reader.ReadUInt32();
+        var modelSize = reader.ReadUInt32();
+        var auxMaterialFlags = version == 4 ? reader.ReadUInt32() : 0;
+        var auxMaterialOffset = version == 4 ? reader.ReadUInt32() : 0;
+        var auxMaterialSize = version == 4 ? reader.ReadUInt32() : 0;
+
+        var transparency = (auxMaterialFlags & 0x1) != 0;
+        var selfIllumination = (auxMaterialFlags & 0x2) != 0;
+
+        var vertexPositions = new List<Vector3>(vertexPositionCount);
+        reader.BaseStream.Seek(vertexPositionOffset, SeekOrigin.Begin);
+        for (var i = 0; i < vertexPositionCount; i++)
+        {
+            vertexPositions.Add(reader.ReadVec3());
+        }
+
+        var vertexUvCount = (int)((vHotOffset - vertexUvOffset) / 8);
+        var vertexUvs = new List<Vector2>(vertexUvCount);
+        reader.BaseStream.Seek(vertexUvOffset, SeekOrigin.Begin);
+        for (var i = 0; i < vertexUvCount; i++)
+        {
+            vertexUvs.Add(reader.ReadVec2());
+        }
+
+        var vertexNormalCount = (int)((faceNormalOffset - vertexNormalOffset) / 8);
+        var vertexNormals = new List<ModelVertexNormal>(vertexNormalCount);
+        reader.BaseStream.Seek(vertexNormalOffset, SeekOrigin.Begin);
+        for (var i = 0; i < vertexNormalCount; i++)
+        {
+            var vnMaterialId = reader.ReadUInt16();
+            var vnVertexId = reader.ReadUInt16();
+            var vnCompactNormal = reader.ReadUInt32();
+            var vnNormal = new Vector3(
+                ((vnCompactNormal >> 16) & 0xFFC0) / 16384.0f,
+                ((vnCompactNormal >> 6) & 0xFFC0) / 16384.0f,
+                ((vnCompactNormal << 4) & 0xFFC0) / 16384.0f);
+            vertexNormals.Add(new ModelVertexNormal
+            {
+                MaterialId = vnMaterialId,
+                VertexId = vnVertexId,
+                Normal = vnNormal,
+            });
+        }
+
+        var faceNormalCount = (int)((polygonOffset - faceNormalOffset) / 12);
+        var faceNormals = new List<Vector3>(faceNormalCount);
+        reader.BaseStream.Seek(faceNormalOffset, SeekOrigin.Begin);
+        for (var i = 0; i < faceNormalCount; i++)
+        {
+            faceNormals.Add(reader.ReadVec3());
+        }
+
+        var vhots = new List<ModelVHot>(vHotCount);
+        reader.BaseStream.Seek(vHotOffset, SeekOrigin.Begin);
+        for (var i = 0; i < vHotCount; i++)
+        {
+            vhots.Add(new ModelVHot
+            {
+                Type = (ModelVHotType)reader.ReadInt32(),
+                Position = reader.ReadVec3(),
+            });
+        }
+
+        var polygons = new List<ModelPolygon>(polygonCount);
+        reader.BaseStream.Seek(polygonOffset, SeekOrigin.Begin);
+        for (var i = 0; i < polygonCount; i++)
+        {
+            var polyIndex = reader.ReadUInt16();
+            var polyData = reader.ReadUInt16();
+            var polyRawType = reader.ReadByte();
+            var polyType = (ModelPolygonType)(polyRawType & 0x07);
+            var polyColorType = (ModelPolygonColorType)((polyRawType & 0x60) >> 5);
+            var polyUseVertexNormals = (polyRawType & 0x18) != 0;
+            var polyVertexCount = reader.ReadByte();
+            var polyNormalIndex = reader.ReadUInt16();
+            var polyNormalDistance = reader.ReadSingle();
+            var polyVertexIndicesRaw = new ushort[3 * polyVertexCount];
+            for (var j = 0; j < 3 * polyVertexCount; j++)
+            {
+                if (j >= 2 * polyVertexCount && polyType != ModelPolygonType.Textured)
+                {
+                    polyVertexIndicesRaw[j] = 0;
+                    continue;
+                }
+
+                polyVertexIndicesRaw[j] = reader.ReadUInt16();
+            }
+
+            var polyVertexIndices = new List<ModelPolygonVertex>(polyVertexCount);
+            for (var j = 0; j < polyVertexCount; j++)
+            {
+                polyVertexIndices.Add(new ModelPolygonVertex
+                {
+                    PositionIndex = polyVertexIndicesRaw[j],
+                    NormalIndex = polyVertexIndicesRaw[j + polyVertexCount],
+                    UvIndex = polyVertexIndicesRaw[j + 2 * polyVertexCount],
+                });
+            }
+
+            var polyMaterialId = version == 4 ? reader.ReadByte() : (byte)0;
+
+            polygons.Add(new ModelPolygon
+            {
+                Index = polyIndex,
+                Type = polyType,
+                ColorType = polyColorType,
+                Data = polyData,
+                UseVertexNormals = polyUseVertexNormals,
+                NormalIndex = polyNormalIndex,
+                NormalDistance = polyNormalDistance,
+                VertexIndices = polyVertexIndices,
+                MaterialId = polyMaterialId,
+            });
+        }
+
+        var objects = new List<ModelObject>(objectCount);
+        reader.BaseStream.Seek(objectOffset, SeekOrigin.Begin);
+        for (var i = 0; i < objectCount; i++)
+        {
+            var objName = reader.ReadNullString(8);
+            var objJointType = (ModelObjectType)reader.ReadByte();
+            var objJointIndex = reader.ReadInt32();
+            var objJointMinValue = reader.ReadSingle();
+            var objJointMaxValue = reader.ReadSingle();
+            var v1 = reader.ReadVec3();
+            var v2 = reader.ReadVec3();
+            var v3 = reader.ReadVec3();
+            var v4 = reader.ReadVec3();
+            var objTransform = new Matrix4x4(
+                v1.X, v1.Y, v1.Z, 0,
+                v2.X, v2.Y, v2.Z, 0,
+                v3.X, v3.Y, v3.Z, 0,
+                v4.X, v4.Y, v4.Z, 1);
+            var objChild = reader.ReadInt16();
+            var objNext = reader.ReadInt16();
+            var objVhotStartIdx = reader.ReadUInt16();
+            var objVhotCount = reader.ReadUInt16();
+            var objVertexStartIdx = reader.ReadUInt16();
+            var objVertexCount = reader.ReadUInt16();
+            var objVertexNormalStartIdx = reader.ReadUInt16();
+            var objVertexNormalCount = reader.ReadUInt16();
+            var objFaceNormalStartIdx = reader.ReadUInt16();
+            var objFaceNormalCount = reader.ReadUInt16();
+            var objNodeStartIdx = reader.ReadUInt16();
+            var objNodeCount = reader.ReadUInt16();
+
+            objects.Add(new ModelObject
+            {
+                Name = objName,
+                JointType = objJointType,
+                JointIndex = objJointIndex,
+                JointMinValue = objJointMinValue,
+                JointMaxValue = objJointMaxValue,
+                Transform = objTransform,
+                ChildObjectIndex = objChild,
+                SiblingObjectIndex = objNext,
+                VHotStartIndex = objVhotStartIdx,
+                VHotCount = objVhotCount,
+                VertexPositionStartIndex = objVertexStartIdx,
+                VertexPositionCount = objVertexCount,
+                VertexNormalStartIndex = objVertexNormalStartIdx,
+                VertexNormalCount = objVertexNormalCount,
+                FaceNormalStartIndex = objFaceNormalStartIdx,
+                FaceNormalCount = objFaceNormalCount,
+                BspNodeStartIndex = objNodeStartIdx,
+                BspNodeCount = objNodeCount,
+            });
+        }
+
+        var materials = new List<ModelMaterial>(materialCount);
+        reader.BaseStream.Seek(materialOffset, SeekOrigin.Begin);
+        for (var i = 0; i < materialCount; i++)
+        {
+            var matName = reader.ReadNullString(16);
+            var matType = (ModelMaterialType)reader.ReadByte();
+            var matSlot = reader.ReadByte();
+            var matColor = Color.FromArgb(reader.ReadInt32());
+            var matPaletteIndex = reader.ReadUInt32();
+
+            materials.Add(new ModelMaterial
+            {
+                Name = matName,
+                Type = matType,
+                Slot = matSlot,
+                Color = matColor,
+                PaletteIndex = matPaletteIndex,
+                Transparency = 0,
+                SelfIllumination = 0,
+                MaxTexelSize = default,
+            });
+        }
+
+        if (version == 4)
+        {
+            reader.BaseStream.Seek(auxMaterialOffset, SeekOrigin.Begin);
+            for (var i = 0; i < materialCount; i++)
+            {
+                materials[i].Transparency = reader.ReadSingle();
+                materials[i].SelfIllumination = reader.ReadSingle();
+                if (auxMaterialSize == 16)
+                {
+                    materials[i].MaxTexelSize = reader.ReadVec2();
+                }
+            }
+        }
+
+        reader.BaseStream.Seek(vertexNormalOffset, SeekOrigin.Begin);
+        var bspNodeData = reader.ReadBytes((int)(modelSize - nodeOffset)).ToList();
+
+        return new ModelFile
+        {
+            Version = version,
+            Name = name,
+            Radius = radius,
+            MaxPolygonRadius = maxPolygonRadius,
+            MinBounds = minBounds,
+            MaxBounds = maxBounds,
+            Center = center,
+            Transparency = transparency,
+            SelfIllumination = selfIllumination,
+            JointCount = jointCount,
+            VCallCount = vCallCount,
+            VertexPositions = vertexPositions,
+            VertexUvs = vertexUvs,
+            VertexNormals = vertexNormals,
+            FaceNormals = faceNormals,
+            Polygons = polygons,
+            VHots = vhots,
+            Materials = materials,
+            Objects = objects,
+            BspNodeData = bspNodeData
+        };
+    }
+
+    public void Write(BinaryWriter writer)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/KeepersCompound.Formats/Model/ModelMaterial.cs
+++ b/KeepersCompound.Formats/Model/ModelMaterial.cs
@@ -1,0 +1,47 @@
+using System.Drawing;
+using System.Numerics;
+
+namespace KeepersCompound.Formats.Model;
+
+public class ModelMaterial
+{
+    /// <summary>
+    /// Maximum 16 characters. Filename including extension when textured.
+    /// </summary>
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// Material type.
+    /// </summary>
+    public required ModelMaterialType Type { get; set; }
+
+    /// <summary>
+    /// Unique ID of the material.
+    /// </summary>
+    public required byte Slot { get; set; }
+
+    /// <summary>
+    /// How transparent is this material? Range 0-1. Only applies on <see cref="ModelFile.Version"/> 4.
+    /// </summary>
+    public required float Transparency { get; set; }
+
+    /// <summary>
+    /// How self-illuminating is this material? Range 0-1. Only applies on <see cref="ModelFile.Version"/> 4.
+    /// </summary>
+    public required float SelfIllumination { get; set; }
+
+    /// <summary>
+    /// Previous format specs online have this as MaxTexelSize but the values seem like garbage to me.
+    /// </summary>
+    public required Vector2 MaxTexelSize { get; set; }
+
+    /// <summary>
+    /// ARGB colour. Only relevant when <see cref="Type"/> is <see cref="ModelMaterialType.Color"/>.
+    /// </summary>
+    public required Color Color { get; set; }
+
+    /// <summary>
+    /// Index into the global engine palette.  Only relevant when <see cref="Type"/> is <see cref="ModelMaterialType.Color"/>.
+    /// </summary>
+    public required uint PaletteIndex { get; set; }
+}

--- a/KeepersCompound.Formats/Model/ModelMaterialType.cs
+++ b/KeepersCompound.Formats/Model/ModelMaterialType.cs
@@ -1,0 +1,7 @@
+namespace KeepersCompound.Formats.Model;
+
+public enum ModelMaterialType
+{
+    Texture,
+    Color,
+}

--- a/KeepersCompound.Formats/Model/ModelObject.cs
+++ b/KeepersCompound.Formats/Model/ModelObject.cs
@@ -1,0 +1,96 @@
+using System.Numerics;
+
+namespace KeepersCompound.Formats.Model;
+
+public class ModelObject
+{
+    /// <summary>
+    /// Maximum 8 characters. Additional characters will be truncated on write.
+    /// </summary>
+    public required string Name { get; set; }
+    
+    /// <summary>
+    /// Joint movement type.
+    /// </summary>
+    public required ModelObjectType JointType { get; set; }
+    
+    /// <summary>
+    /// Which joint parameter to apply.
+    /// </summary>
+    public required int JointIndex { get; set; }
+    
+    /// <summary>
+    /// Minimum allowable value for the joint parameter.
+    /// </summary>
+    public required float JointMinValue { get; set; }
+    
+    /// <summary>
+    /// Maximum allowable value for the joint parameter.
+    /// </summary>
+    public required float JointMaxValue { get; set; }
+    
+    /// <summary>
+    /// Base transform to apply to object vertices and vhots
+    /// </summary>
+    public required Matrix4x4 Transform { get; set; }
+    
+    /// <summary>
+    /// Index of the first child object. -1 if no children.
+    /// </summary>
+    public required short ChildObjectIndex { get; set; }
+    
+    /// <summary>
+    /// Index of the next sibling object. -1 if no more siblings.
+    /// </summary>
+    public required short SiblingObjectIndex { get; set; }
+    
+    /// <summary>
+    /// Index into <see cref="ModelFile.VHots"/> of the first VHot used by this object.
+    /// </summary>
+    public required ushort VHotStartIndex { get; set; }
+    
+    /// <summary>
+    /// Number of VHots used by this object.
+    /// </summary>
+    public required ushort VHotCount { get; set; }
+    
+    /// <summary>
+    /// Index into <see cref="ModelFile.VertexPositions"/> of the first vertex position used by this object.
+    /// </summary>
+    public required ushort VertexPositionStartIndex { get; set; }
+    
+    /// <summary>
+    /// Number of vertex positions used by this object.
+    /// </summary>
+    public required ushort VertexPositionCount { get; set; }
+    
+    /// <summary>
+    /// Index into <see cref="ModelFile.VertexNormals"/> of the first vertex normal used by this object.
+    /// </summary>
+    public required ushort VertexNormalStartIndex { get; set; }
+    
+    /// <summary>
+    /// Number of vertex normals used by this object.
+    /// </summary>
+    public required ushort VertexNormalCount { get; set; }
+    
+    /// <summary>
+    /// Index into <see cref="ModelFile.FaceNormals"/> of the first face normal used by this object.
+    /// </summary>
+    public required ushort FaceNormalStartIndex { get; set; }
+    
+    /// <summary>
+    /// Number of face normals used by this object.
+    /// </summary>
+    public required ushort FaceNormalCount { get; set; }
+    
+    /// <summary>
+    /// Index into <see cref="ModelFile.BspNodes"/> of the first BSP node used by this object.
+    /// </summary>
+    public required ushort BspNodeStartIndex { get; set; }
+    
+    /// <summary>
+    /// Number of BSP nodes used by this object.
+    /// </summary>
+    public required ushort BspNodeCount { get; set; }
+}

--- a/KeepersCompound.Formats/Model/ModelObjectType.cs
+++ b/KeepersCompound.Formats/Model/ModelObjectType.cs
@@ -1,0 +1,8 @@
+namespace KeepersCompound.Formats.Model;
+
+public enum ModelObjectType
+{
+    Static,
+    Rotating,
+    Sliding,
+}

--- a/KeepersCompound.Formats/Model/ModelPolygon.cs
+++ b/KeepersCompound.Formats/Model/ModelPolygon.cs
@@ -1,0 +1,45 @@
+namespace KeepersCompound.Formats.Model;
+
+public class ModelPolygon
+{
+    /// <summary>
+    /// Usually equal to the position of the poly in <see cref="ModelFile.Polygons"/>.
+    /// </summary>
+    public required ushort Index { get; set; }
+
+    /// <summary>
+    /// What type of polygon are we? Affects how <see cref="Data"/> is used.
+    /// </summary>
+    public required ModelPolygonType Type { get; set; }
+    public required ModelPolygonColorType ColorType { get; set; }
+
+    /// <summary>
+    /// Used as either an engine palette index or a material <see cref="ModelMaterial.Slot"/> depending on <see cref="Type"/>.
+    /// </summary>
+    public required ushort Data { get; set; }
+
+    /// <summary>
+    /// Should the vertex normals be used or ignored?
+    /// </summary>
+    public required bool UseVertexNormals { get; set; }
+
+    /// <summary>
+    /// Index into <see cref="ModelFile.FaceNormals"/>.
+    /// </summary>
+    public required ushort NormalIndex { get; set; }
+
+    /// <summary>
+    /// Distance of normal along <see cref="NormalIndex"/>.
+    /// </summary>
+    public required float NormalDistance { get; set; }
+
+    /// <summary>
+    /// Indices into the appropriate global model vertex data lists.
+    /// </summary>
+    public required List<ModelPolygonVertex> VertexIndices { get; set; }
+
+    /// <summary>
+    /// ID of the material used by this polygon. Only used in <see cref="ModelFile.Version"/> 4.
+    /// </summary>
+    public required byte MaterialId { get; set; }
+}

--- a/KeepersCompound.Formats/Model/ModelPolygonColorType.cs
+++ b/KeepersCompound.Formats/Model/ModelPolygonColorType.cs
@@ -1,0 +1,19 @@
+namespace KeepersCompound.Formats.Model;
+
+public enum ModelPolygonColorType
+{
+    /// <summary>
+    /// Only valid value when <see cref="ModelPolygonType.Textured"/>
+    /// </summary>
+    None,
+    
+    /// <summary>
+    /// Polygon color indexes engine palette by <see cref="ModelPolygon.Data"/>.
+    /// </summary>
+    Paletted,
+    
+    /// <summary>
+    /// Polygon color uses coloured material with <see cref="ModelMaterial.Slot"/> equal to <see cref="ModelPolygon.Data"/>.
+    /// </summary>
+    Coloured,
+}

--- a/KeepersCompound.Formats/Model/ModelPolygonType.cs
+++ b/KeepersCompound.Formats/Model/ModelPolygonType.cs
@@ -1,0 +1,24 @@
+namespace KeepersCompound.Formats.Model;
+
+public enum ModelPolygonType
+{
+    /// <summary>
+    /// Polygon is unrendered. I've never seen this, but it's theoretically possible.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Polygon is rendered as a ngon wireframe. Should be used in conjunction with <see cref="ModelPolygonColorType.Paletted"/> or <see cref="ModelPolygonColorType. Coloured"/>.
+    /// </summary>
+    Wireframe,
+
+    /// <summary>
+    /// Polygon is rendered as a solid color. Should be used in conjunction with <see cref="ModelPolygonColorType.Paletted"/> or <see cref="ModelPolygonColorType. Coloured"/>.
+    /// </summary>
+    Solid,
+    
+    /// <summary>
+    /// Polygon is rendered with a texture using a texture material with <see cref="ModelMaterial.Slot"/> equal to <see cref="ModelPolygon.Data"/>.
+    /// </summary>
+    Textured,
+}

--- a/KeepersCompound.Formats/Model/ModelPolygonVertex.cs
+++ b/KeepersCompound.Formats/Model/ModelPolygonVertex.cs
@@ -1,0 +1,19 @@
+namespace KeepersCompound.Formats.Model;
+
+public class ModelPolygonVertex
+{
+    /// <summary>
+    /// Index into <see cref="ModelFile.VertexPositions"/>.
+    /// </summary>
+    public required ushort PositionIndex { get; set; }
+
+    /// <summary>
+    /// Index into <see cref="ModelFile.VertexNormals"/>.
+    /// </summary>
+    public required ushort NormalIndex { get; set; }
+
+    /// <summary>
+    /// Index into <see cref="ModelFile.VertexUvs"/>. Only used for textured polygons.
+    /// </summary>
+    public required ushort UvIndex { get; set; }
+}

--- a/KeepersCompound.Formats/Model/ModelVHot.cs
+++ b/KeepersCompound.Formats/Model/ModelVHot.cs
@@ -1,0 +1,16 @@
+using System.Numerics;
+
+namespace KeepersCompound.Formats.Model;
+
+public class ModelVHot
+{
+    /// <summary>
+    /// Which type of VHot is it? VHot types on a model must be unique.
+    /// </summary>
+    public required ModelVHotType Type { get; set; }
+
+    /// <summary>
+    /// Position in global space. When <see cref="Type"/> is <see cref="ModelVHotType.LightDirection"/> the direction is <see cref="Position"/> relative to the <see cref="ModelVHotType.LightPosition"/> VHot.
+    /// </summary>
+    public required Vector3 Position { get; set; }
+}

--- a/KeepersCompound.Formats/Model/ModelVHotType.cs
+++ b/KeepersCompound.Formats/Model/ModelVHotType.cs
@@ -1,0 +1,13 @@
+namespace KeepersCompound.Formats.Model;
+
+public enum ModelVHotType
+{
+    LightPosition = 1,
+    LightDirection = 8,
+    Anchor = 2,
+    Particle1 = 3,
+    Particle2 = 4,
+    Particle3 = 5,
+    Particle4 = 6,
+    Particle5 = 7,
+}

--- a/KeepersCompound.Formats/Model/ModelVertexNormal.cs
+++ b/KeepersCompound.Formats/Model/ModelVertexNormal.cs
@@ -1,0 +1,10 @@
+using System.Numerics;
+
+namespace KeepersCompound.Formats.Model;
+
+public class ModelVertexNormal
+{
+    public required ushort MaterialId { get; set; }
+    public required ushort VertexId { get; set; }
+    public required Vector3 Normal { get; set; }
+}


### PR DESCRIPTION
Beginning of work splitting out the raw file parsing and representations into it's own project inspired by [Sledge.Formas](https://github.com/LogicAndTrick/sledge-formats). Realistically it's only me that's going to be using it for now, but if anyone works with my code in the future it will be nice to not necessarily have to use my more opinionated abstractions in the main library.

Another part of this split is separating the actual parsing from the representations. Could have been done in the main project but meh. This PR mostly just has `.bin` model parsing (because I need it for the model editor tool), but there's a basic start on reworking the tag/dbfiles too.

Note: This project isn't actually being used by KCTools or LGS yet.