### PR TITLE
Add ModelFile helper functions

### DIFF
--- a/KeepersCompound.Formats/Model/ModelFile.cs
+++ b/KeepersCompound.Formats/Model/ModelFile.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
 namespace KeepersCompound.Formats.Model;
@@ -100,4 +101,136 @@ public class ModelFile
     /// Unknown structure at this point.
     /// </summary>
     public required List<byte> BspNodeData { get; set; }
+
+    /// <summary>
+    /// Get the transforms to apply to each <see cref="ModelObject"/> after applying joint values.
+    /// </summary>
+    /// <param name="baseTransform">Base transform of the model.</param>
+    /// <param name="jointValues">Values for each joint. Note that DromEd properties only expose 6 joints, but there can be many more.</param>
+    /// <returns></returns>
+    public List<Matrix4x4> GetObjectTransforms(Matrix4x4 baseTransform, List<float> jointValues)
+    {
+        // Build map of objects to their parent id
+        var objCount = Objects.Count;
+        var parentIds = new int[objCount];
+        for (var i = 0; i < objCount; i++)
+        {
+            parentIds[i] = -1;
+        }
+
+        for (var i = 0; i < objCount; i++)
+        {
+            var subObj = Objects[i];
+            var childIdx = subObj.ChildObjectIndex;
+            while (childIdx != -1)
+            {
+                parentIds[childIdx] = i;
+                childIdx = Objects[childIdx].SiblingObjectIndex;
+            }
+        }
+
+        // Calculate base transforms for every subobj (including joint)
+        var subObjTransforms = new Matrix4x4[objCount];
+        for (var i = 0; i < objCount; i++)
+        {
+            var subObj = Objects[i];
+            var jointValue = subObj.JointIndex >= jointValues.Count ? 0 : jointValues[subObj.JointIndex];
+            subObjTransforms[i] = subObj.JointType switch
+            {
+                ModelObjectType.Rotating when subObj.JointIndex != -1 =>
+                    Matrix4x4.CreateFromYawPitchRoll(0, float.DegreesToRadians(jointValue), 0) * subObj.Transform,
+                ModelObjectType.Sliding when subObj.JointIndex != -1 =>
+                    Matrix4x4.CreateTranslation(jointValue, 0, 0) * subObj.Transform,
+                _ => Matrix4x4.Identity,
+            };
+        }
+
+        // Final transforms are composed by climbing the hierarchy and applying parent transforms
+        var transforms = new List<Matrix4x4>(objCount);
+        for (var i = 0; i < objCount; i++)
+        {
+            var transform = subObjTransforms[i];
+
+            // Build compound transformation
+            var parentId = parentIds[i];
+            while (parentId != -1)
+            {
+                transform *= subObjTransforms[parentId];
+                parentId = parentIds[parentId];
+            }
+
+            transform *= baseTransform;
+            transforms[i] = transform;
+        }
+
+        return transforms;
+    }
+
+    /// <summary>
+    /// Attempt to get a vhot of a given type.
+    /// </summary>
+    /// <param name="type">Which vhot type is being requested</param>
+    /// <param name="vhot">The found vhot. Null if not found.</param>
+    /// <returns>True if the vhot was found, false otherwise.</returns>
+    public bool TryGetVhot(ModelVHotType type, [MaybeNullWhen(false)] out ModelVHot vhot)
+    {
+        foreach (var v in VHots)
+        {
+            if (v.Type == type)
+            {
+                vhot = v;
+                return true;
+            }
+        }
+
+        vhot = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Determine which <see cref="ModelObject"/> a <see cref="ModelPolygon"/> belongs to.
+    /// </summary>
+    /// <param name="polygon">Target polygon.</param>
+    /// <returns>The index of the owning <see cref="ModelObject"/> in <see cref="Objects"/> if one exists otherwise -1.</returns>
+    public int GetPolygonObjectMapping(ModelPolygon polygon)
+    {
+        // The simplest way to detect which object a polygon belongs to is to just check if a vertex position index of
+        // the polygon is within the objects vertex position range.
+        var vertexIndex = polygon.VertexIndices[0].PositionIndex;
+        for (var i = 0; i < Objects.Count; i++)
+        {
+            var obj = Objects[i];
+            var start = (int)obj.VertexPositionStartIndex;
+            var end = start + obj.VertexPositionCount;
+            if (start <= vertexIndex && vertexIndex < end)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Determine which <see cref="ModelObject"/> a <see cref="ModelVHot"/> belongs to.
+    /// </summary>
+    /// <param name="type">Target vhot.</param>
+    /// <returns>The index of the owning <see cref="ModelObject"/> in <see cref="Objects"/> if one exists otherwise -1.</returns>
+    public int GetVhotObjectMapping(ModelVHotType type)
+    {
+        for (var i = 0; i < Objects.Count; i++)
+        {
+            var obj = Objects[i];
+            for (var j = 0; j < obj.VHotCount; j++)
+            {
+                var vhot = VHots[obj.VHotStartIndex + j];
+                if (vhot.Type == type)
+                {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
 }


### PR DESCRIPTION
`GetObjectTransforms` and `TryGetVHot` are based on existing helpers in the old parser. `GetPolygonObjectMapping` and `GetVhotObjectMapping` are used to replace the old mapping fields.