### PR TITLE
Faster vis calculations

### DIFF
--- a/KeepersCompound.Lighting/Vis/VisGraph.cs
+++ b/KeepersCompound.Lighting/Vis/VisGraph.cs
@@ -24,9 +24,23 @@ public class VisGraph
         var visitedNodes = new Stack<int>();
         visitedNodes.Push(startNode);
 
+        // Lists used in clipping. Pre-made here to avoid allocations each time we clip.
+        var clipDistances = new List<float>(32);
+        var clipSides = new List<VisGraphClipSide>(32);
+        var clipCounts = new[] { 0, 0, 0 };
+
         foreach (var edge in _nodes[startNode])
         {
-            ComputeVisibleNodesRecursive(visibleNodes, visitedNodes, position, maxRange, edge.Destination, edge.Poly);
+            ComputeVisibleNodesRecursive(
+                visibleNodes,
+                visitedNodes,
+                position,
+                maxRange,
+                edge.Destination,
+                edge.Poly,
+                clipDistances,
+                clipSides,
+                clipCounts);
         }
 
         return visibleNodes;
@@ -38,7 +52,10 @@ public class VisGraph
         Vector3 position,
         float maxRange,
         int currentNode,
-        VisGraphPoly passPoly)
+        VisGraphPoly passPoly,
+        List<float> clipDistances,
+        List<VisGraphClipSide> clipSides,
+        int[] clipCounts)
     {
         visitedNodes.Push(currentNode);
         visibleNodes.Add(currentNode);
@@ -76,7 +93,7 @@ public class VisGraph
             var poly = edge.Poly with { Vertices = [..edge.Poly.Vertices] };
             foreach (var clipPlane in clipPlanes)
             {
-                ClipPolygonByPlane(ref poly, clipPlane);
+                ClipPolygonByPlane(ref poly, clipPlane, clipDistances, clipSides, clipCounts);
             }
 
             if (poly.Vertices.Count == 0)
@@ -84,13 +101,27 @@ public class VisGraph
                 continue;
             }
 
-            ComputeVisibleNodesRecursive(visibleNodes, visitedNodes, position, maxRange, edge.Destination, poly);
+            ComputeVisibleNodesRecursive(
+                visibleNodes,
+                visitedNodes,
+                position,
+                maxRange,
+                edge.Destination,
+                poly,
+                clipDistances,
+                clipSides,
+                clipCounts);
         }
 
         visitedNodes.Pop();
     }
 
-    private static void ClipPolygonByPlane(ref VisGraphPoly poly, Plane plane)
+    private static void ClipPolygonByPlane(
+        ref VisGraphPoly poly,
+        Plane plane,
+        List<float> clipDistances,
+        List<VisGraphClipSide> clipSides,
+        int[] clipCounts)
     {
         var vertexCount = poly.Vertices.Count;
         if (vertexCount == 0)
@@ -100,30 +131,33 @@ public class VisGraph
 
         // Firstly we want to tally up what side of the plane each point of the poly is on
         // This is used both to early out if nothing/everything is clipped, and to aid the clipping
-        var distances = new float[vertexCount];
-        var sides = new VisGraphClipSide[vertexCount];
-        var counts = new[] { 0, 0, 0 };
+        clipDistances.Clear();
+        clipSides.Clear();
+        clipCounts[0] = 0;
+        clipCounts[1] = 0;
+        clipCounts[2] = 0;
         for (var i = 0; i < vertexCount; i++)
         {
             var distance = MathUtils.DistanceFromPlane(plane, poly.Vertices[i]);
-            distances[i] = distance;
-            sides[i] = distance switch
+            var side = distance switch
             {
                 > Epsilon => VisGraphClipSide.Front,
                 < -Epsilon => VisGraphClipSide.Back,
                 _ => VisGraphClipSide.On,
             };
-            counts[(int)sides[i]]++;
+            clipDistances.Add(distance);
+            clipSides.Add(side);
+            clipCounts[(int)side]++;
         }
 
         // Everything is within the half-space, so we don't need to clip anything
-        if (counts[(int)VisGraphClipSide.Back] == 0 && counts[(int)VisGraphClipSide.On] != vertexCount)
+        if (clipCounts[(int)VisGraphClipSide.Back] == 0 && clipCounts[(int)VisGraphClipSide.On] != vertexCount)
         {
             return;
         }
 
         // Everything is outside the half-space, so we clip everything
-        if (counts[(int)VisGraphClipSide.Front] == 0)
+        if (clipCounts[(int)VisGraphClipSide.Front] == 0)
         {
             poly.Vertices.Clear();
             return;
@@ -135,11 +169,11 @@ public class VisGraph
             var i1 = (i + 1) % vertexCount;
             var v0 = poly.Vertices[i];
             var v1 = poly.Vertices[i1];
-            var side = sides[i];
-            var nextSide = sides[i1];
+            var side = clipSides[i];
+            var nextSide = clipSides[i1];
 
             // Vertices that are inside/on the half-space don't get clipped
-            if (sides[i] != VisGraphClipSide.Back)
+            if (clipSides[i] != VisGraphClipSide.Back)
             {
                 vertices.Add(v0);
             }
@@ -153,7 +187,7 @@ public class VisGraph
             }
 
             // This is how far along the vector v0 -> v1 the front/back crossover occurs
-            var frac = distances[i] / (distances[i] - distances[i1]);
+            var frac = clipDistances[i] / (clipDistances[i] - clipDistances[i1]);
             var splitVertex = v0 + frac * (v1 - v0);
             vertices.Add(splitVertex);
         }

--- a/KeepersCompound.Lighting/Vis/VisGraph.cs
+++ b/KeepersCompound.Lighting/Vis/VisGraph.cs
@@ -86,7 +86,7 @@ public class VisGraph
             // Could probably use poly center + radius to get an even better early out.
             if (visitedNodes.Contains(edge.Destination) ||
                 (edge.Poly.Center - position).Length() > maxRange + edge.Poly.Radius ||
-                Math.Abs(MathUtils.DistanceFromNormalizedPlane(edge.Poly.Plane, position)) > maxRange)
+                MathUtils.DistanceFromNormalizedPlane(edge.Poly.Plane, position) < -Epsilon)
             {
                 continue;
             }

--- a/KeepersCompound.Lighting/Vis/VisGraph.cs
+++ b/KeepersCompound.Lighting/Vis/VisGraph.cs
@@ -85,15 +85,16 @@ public class VisGraph
             // This only checks is there is a point on the plane in range.
             // Could probably use poly center + radius to get an even better early out.
             if (visitedNodes.Contains(edge.Destination) ||
+                (edge.Poly.Center - position).Length() > maxRange + edge.Poly.Radius ||
                 Math.Abs(MathUtils.DistanceFromNormalizedPlane(edge.Poly.Plane, position)) > maxRange)
             {
                 continue;
             }
 
-            var poly = edge.Poly with { Vertices = [..edge.Poly.Vertices] };
+            var poly = new VisGraphPoly(edge.Poly);
             foreach (var clipPlane in clipPlanes)
             {
-                ClipPolygonByPlane(ref poly, clipPlane, clipDistances, clipSides, clipCounts);
+                ClipPolygonByPlane(poly, clipPlane, clipDistances, clipSides, clipCounts);
             }
 
             if (poly.Vertices.Count == 0)
@@ -117,7 +118,7 @@ public class VisGraph
     }
 
     private static void ClipPolygonByPlane(
-        ref VisGraphPoly poly,
+        VisGraphPoly poly,
         Plane plane,
         List<float> clipDistances,
         List<VisGraphClipSide> clipSides,

--- a/KeepersCompound.Lighting/Vis/VisGraphPoly.cs
+++ b/KeepersCompound.Lighting/Vis/VisGraphPoly.cs
@@ -2,4 +2,50 @@ using System.Numerics;
 
 namespace KeepersCompound.Lighting.Vis;
 
-public record VisGraphPoly(Plane Plane, List<Vector3> Vertices);
+public class VisGraphPoly
+{
+    public Vector3 Center { get; private set; }
+    public float Radius { get; private set; }
+    public List<Vector3> Vertices { get; }
+    public Plane Plane { get; }
+
+    public VisGraphPoly(Plane plane, List<Vector3> vertices)
+    {
+        Plane = plane;
+        Vertices = vertices;
+        ComputeCenterRadius();
+    }
+
+    public VisGraphPoly(VisGraphPoly other)
+    {
+        Center = other.Center;
+        Radius = other.Radius;
+        Plane = other.Plane;
+        Vertices = [..other.Vertices];
+    }
+
+    /// <summary>
+    /// If vertices are modified then <see cref="Center"/> and <see cref="Radius"/> will be inaccurate and should be
+    /// recomputed before being used.
+    /// </summary>
+    public void ComputeCenterRadius()
+    {
+        Center = Vector3.Zero;
+        foreach (var v in Vertices)
+        {
+            Center += v;
+        }
+
+        Center /= Vertices.Count;
+
+        // Radius is the max vertex distance from the center
+        // We're actually calculating radius squared to begin with because it's faster :)
+        Radius = 0;
+        foreach (var v in Vertices)
+        {
+            Radius = float.Max(Radius, (v - Center).LengthSquared());
+        }
+
+        Radius = MathF.Sqrt(Radius);
+    }
+}


### PR DESCRIPTION
Reduces memory allocations and better early outs during vis calculations. The early outs mean that there are differences in output. Logically and from testing they're correct, but it's possible some edge cases have been introduced.

VisGraph calculation speedup is roughly ~1.5x on maps where it was taking a long time (>1s). On simpler maps the speedup is still there, but less noticeable.