### PR TITLE
Fix resource gathering collecting a lot of irrelevant files

### DIFF
--- a/KeepersCompound.Dark/Resources/ResourceManager.cs
+++ b/KeepersCompound.Dark/Resources/ResourceManager.cs
@@ -35,14 +35,33 @@ public class ResourceManager
 
         for (var i = 0; i < context.LoadPaths.Count; i++)
         {
-            var path =  context.LoadPaths[^(i + 1)];
+            var path = context.LoadPaths[^(i + 1)];
             _vfs.Mount("", path, [".mis", ".gam", ".cow"], false);
         }
 
+        var resSearchOptions = new EnumerationOptions
+        {
+            MatchCasing = MatchCasing.CaseInsensitive
+        };
         for (var i = 0; i < context.ResPaths.Count; i++)
         {
-            var path =  context.ResPaths[^(i + 1)];
-            _vfs.Mount("", path, true);
+            var resPath = context.ResPaths[^(i + 1)];
+            Log.Debug("ResPath: {p}", resPath);
+            foreach (var path in Directory.GetFileSystemEntries(resPath, "*", resSearchOptions))
+            {
+                var name = Path.GetFileName(path).ToLower();
+                switch (name)
+                {
+                    case "fam":
+                    case "obj":
+                        _vfs.Mount(name, path, true);
+                        break;
+                    case "fam.crf":
+                    case "obj.crf":
+                        _vfs.Mount("", path, true);
+                        break;
+                }
+            }
         }
 
         if (campaignName != null && context.Fms.Contains(campaignName))
@@ -115,7 +134,7 @@ public class ResourceManager
 
     public bool TryGetObjectTextureVirtualPath(string name, out string virtualPath)
     {
-        foreach (var prefix in new []{"obj/txt16", "obj/txt"})
+        foreach (var prefix in new[] { "obj/txt16", "obj/txt" })
         {
             foreach (var ext in _textureExtensions)
             {

--- a/KeepersCompound.Dark/Resources/ResourceManager.cs
+++ b/KeepersCompound.Dark/Resources/ResourceManager.cs
@@ -66,7 +66,23 @@ public class ResourceManager
 
         if (campaignName != null && context.Fms.Contains(campaignName))
         {
-            _vfs.Mount("", Path.Join(context.FmsDir, campaignName), true);
+            var fmDir = Path.Join(context.FmsDir, campaignName);
+            _vfs.Mount("", fmDir, [".mis", ".gam", ".cow"], false);
+            foreach (var path in Directory.GetFileSystemEntries(fmDir, "*", resSearchOptions))
+            {
+                var name = Path.GetFileName(path).ToLower();
+                switch (name)
+                {
+                    case "fam":
+                    case "obj":
+                        _vfs.Mount(name, path, true);
+                        break;
+                    case "fam.crf":
+                    case "obj.crf":
+                        _vfs.Mount("", path, true);
+                        break;
+                }
+            }
         }
 
         DbFileNames = _vfs.GetFilesInFolder("", [".mis", ".cow", ".gam"], false);

--- a/KeepersCompound.Dark/Resources/VirtualFileSystem.cs
+++ b/KeepersCompound.Dark/Resources/VirtualFileSystem.cs
@@ -160,6 +160,7 @@ public class VirtualFileSystem
             }
             else
             {
+                virtualPath = NormaliseFilePath(Path.Join(mountPoint, virtualPath));
                 RegisterParentDirectories(virtualPath);
                 _files[virtualPath] = new OsVirtualFile(virtualPath, osPath);
             }
@@ -186,6 +187,7 @@ public class VirtualFileSystem
             }
             else if (validExtensions.Contains(ext))
             {
+                virtualPath = NormaliseFilePath(Path.Join(mountPoint, virtualPath));
                 RegisterParentDirectories(virtualPath);
                 _files[virtualPath] = new OsVirtualFile(virtualPath, osPath);
             }


### PR DESCRIPTION
Files in `resname_base` paths were collected in a lazy way, just recursively grab everything. This could lead to slowdowns and a lot of irrelevant files if `resname_base` contained something like `.\` (actually needed on SS2) often including every file in every FM installed.